### PR TITLE
Need to use the source_ref not source_uid for receptor

### DIFF
--- a/lib/topological_inventory/satellite/connection.rb
+++ b/lib/topological_inventory/satellite/connection.rb
@@ -29,11 +29,11 @@ module TopologicalInventory
       end
 
       # @return [String] UUID - message ID for callbacks
-      def send_availability_check(source_uid, receptor_node_id, receiver)
+      def send_availability_check(source_ref, receptor_node_id, receiver)
         receptor_client.send_directive(account_number,
                                        receptor_node_id,
                                        :directive         => "receptor_satellite:health_check",
-                                       :payload           => {'satellite_instance_id' => source_uid.to_s}.to_json,
+                                       :payload           => {'satellite_instance_id' => source_ref.to_s}.to_json,
                                        :response_object   => receiver,
                                        :response_callback => :availability_check_response,
                                        :timeout_callback  => :availability_check_timeout)

--- a/lib/topological_inventory/satellite/operations/source.rb
+++ b/lib/topological_inventory/satellite/operations/source.rb
@@ -19,7 +19,7 @@ module TopologicalInventory
           :receptor_not_responding      => "Receptor is not responding",
         }.freeze
 
-        attr_accessor :source_id, :source_uid
+        attr_accessor :source_id, :source_uid, :source_ref
 
         def initialize(params = {}, request_context = nil, receptor_client = nil)
           self.params          = params
@@ -27,6 +27,7 @@ module TopologicalInventory
           self.connection      = TopologicalInventory::Satellite::Connection.connection(params["external_tenant"], receptor_client)
           self.source_id       = params['source_id']
           self.source_uid      = params['source_uid']
+          self.source_ref      = params['source_ref']
         end
 
         # Entrypoint for "Source:availability_check" operation
@@ -82,7 +83,7 @@ module TopologicalInventory
 
         def params_missing?
           is_missing = false
-          %w[source_id source_uid].each do |attr|
+          %w[source_id source_ref].each do |attr|
             if (is_missing = params[attr].blank?)
               logger.error("Missing #{attr} for the availability_check request")
               break
@@ -132,7 +133,7 @@ module TopologicalInventory
 
         # @return [String|nil] UUID - message ID for callbacks
         def send_availability_check(receptor_node_id)
-          connection.send_availability_check(source_uid, receptor_node_id, self)
+          connection.send_availability_check(source_ref, receptor_node_id, self)
         end
 
         def update_source_and_endpoint(status, error_message = nil)

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe TopologicalInventory::Satellite::Operations::Source do
   end
 
   describe "#availability_check" do
-    let(:params) { {'source_id' => '1', 'source_uid' => '1234-5678'} }
+    let(:params) { {'source_id' => '1', 'source_uid' => '1234-5678', 'source_ref' => '9101112-13141516'} }
 
     subject { described_class.new(params) }
 


### PR DESCRIPTION
We need to use the satellite source_ref not the source_uid for the receptor controller satellite_instance_id attribute.

Depends: https://github.com/RedHatInsights/sources-api/pull/200