### PR TITLE
Gemfile update (Hakiri warning)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "activesupport", "~> 5.2.2"
+gem "activesupport", '~> 5.2.4.3'
 gem "cloudwatchlogger", "~> 0.2"
 gem "concurrent-ruby"
 gem "faraday", "~> 1.0"
@@ -12,7 +12,7 @@ gem 'manageiq-messaging'
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
-gem "rake"
+gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 1.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0"


### PR DESCRIPTION
Hakiri warnings CVE-2020-8130 and CVE-2020-8165.

Updating the rake and activesupport gem versions.