### PR TITLE
Availability check: "last_checked_at" and "last_available_at" update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,9 @@ gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
-gem "sources-api-client", "~> 1.0"
+gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0"
-gem "topological_inventory-providers-common", "~> 0.1"
+gem "topological_inventory-providers-common", "~> 1.0.3"
 group :development, :test do
   gem "rspec"
   gem 'rubocop',             "~>0.69.0", :require => false

--- a/lib/topological_inventory/satellite/operations/core/authentication_retriever.rb
+++ b/lib/topological_inventory/satellite/operations/core/authentication_retriever.rb
@@ -35,7 +35,10 @@ module TopologicalInventory
               :headers => headers
             }
             response = RestClient::Request.new(request_options).execute
-            SourcesApiClient::Authentication.new(JSON.parse(response.body))
+            params = JSON.parse(response.body)
+            # public API doesn't return tenant but internal API does
+            params.delete('tenant')
+            SourcesApiClient::Authentication.new(params)
           end
         end
       end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/206

Updating of "last_checked_at" and "last_available_at" timestamps in Source and Endpoint (Sources API)

Availability check checks the `Endpoint.last_checked_at` and skips new testing if last check was less than 5 minutes ago. 
This will prevent processing many availability checks with big kafka lag. 

---

[TPINVTRY-944](https://projects.engineering.redhat.com/browse/TPINVTRY-944)
