### PR TITLE
Add HealthCheck operation after message process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0"
-gem "topological_inventory-providers-common", "~> 1.0.3"
+gem "topological_inventory-providers-common", "~> 1.0.10"
 group :development, :test do
   gem "rspec"
   gem 'rubocop',             "~>0.69.0", :require => false

--- a/lib/topological_inventory/satellite/operations/worker.rb
+++ b/lib/topological_inventory/satellite/operations/worker.rb
@@ -3,6 +3,7 @@ require "topological_inventory/satellite/logging"
 require "topological_inventory/satellite/receptor/client"
 require "topological_inventory/satellite/operations/processor"
 require "topological_inventory/satellite/operations/source"
+require "topological_inventory/providers/common/operations/health_check"
 
 module TopologicalInventory
   module Satellite
@@ -41,6 +42,7 @@ module TopologicalInventory
           raise
         ensure
           message.ack
+          TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file
         end
 
         def queue_name


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-1055

I am going to add a  to the deployment template that will check if the file has been touched for the last 2 hours, if it has not then OCP will restart the pod for us.

DEPENDS ON:
- [x] [Health Check File Added](https://github.com/RedHatInsights/topological_inventory-providers-common/pull/48)
- [x] [Provider-common gem released](https://github.com/RedHatInsights/topological_inventory-providers-common/pull/49)