### PR TITLE
Custom metrics for operations

### DIFF
--- a/bin/satellite-operations
+++ b/bin/satellite-operations
@@ -6,9 +6,12 @@ require "active_support/core_ext/object/blank"
 require "optimist"
 require "topological_inventory/satellite/receptor/client"
 require "topological_inventory/satellite/operations/worker"
+require "topological_inventory/satellite/operations/metrics"
 
 def parse_args
   Optimist.options do
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
+        :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
     opt :queue_host, "Kafka messaging: hostname or IP", :type => :string, :default => ENV["QUEUE_HOST"] || "localhost"
     opt :queue_port, "Kafka messaging: port", :type => :integer, :default => (ENV["QUEUE_PORT"] || 9092).to_i
     opt :receptor_controller_scheme, "Receptor Controller scheme", :type => :string, :default => ENV["RECEPTOR_CONTROLLER_SCHEME"] || "http"
@@ -47,8 +50,14 @@ TopologicalInventory::Satellite::MessagingClient.configure do |config|
   config.queue_port = args[:queue_port]
 end
 
+metrics = TopologicalInventory::Satellite::Operations::Metrics.new(args[:metrics_port])
+operations_worker = TopologicalInventory::Satellite::Operations::Worker.new(metrics)
+Signal.trap("TERM") do
+  metrics.stop_server
+  exit
+end
+
 begin
-  operations_worker = TopologicalInventory::Satellite::Operations::Worker.new(:metrics => metrics)
   operations_worker.run
 rescue => err
   puts err

--- a/lib/topological_inventory/satellite/operations/metrics.rb
+++ b/lib/topological_inventory/satellite/operations/metrics.rb
@@ -1,0 +1,17 @@
+require 'topological_inventory/providers/common/metrics'
+
+module TopologicalInventory
+  module Satellite
+    module Operations
+      class Metrics < TopologicalInventory::Providers::Common::Metrics
+        def initialize(port = 9394)
+          super(port)
+        end
+
+        def default_prefix
+          "topological_inventory_satellite_operations_"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/satellite/operations/processor.rb
+++ b/lib/topological_inventory/satellite/operations/processor.rb
@@ -1,44 +1,48 @@
 require "topological_inventory/satellite/logging"
+require "topological_inventory/satellite/operations/source"
+require "topological_inventory/providers/common/operations/processor"
 
 module TopologicalInventory
   module Satellite
     module Operations
-      class Processor
+      class Processor < TopologicalInventory::Providers::Common::Operations::Processor
         include Logging
 
-        def self.process!(message, receptor_client)
-          new(message, receptor_client).process
+        def self.process!(message, metrics, receptor_client)
+          new(message, metrics, receptor_client).process
         end
 
-        def initialize(message, receptor_client)
-          self.message = message
-          self.model, self.method = message.message.split(".")
-
-          self.params   = message.payload["params"]
-          self.identity = message.payload["request_context"]
+        def initialize(message, metrics, receptor_client)
+          super(message, metrics)
           self.receptor_client = receptor_client
         end
 
         def process
           logger.info(status_log_msg)
-
-          impl = Operations.const_get(model).new(params, identity, receptor_client) if Operations.const_defined?(model)
+          impl = operation_class&.new(params, identity, metrics, receptor_client)
           if impl&.respond_to?(method)
-            result = impl.send(method)
+            with_time_measure do
+              result = impl.send(method)
 
-            logger.info(status_log_msg("Complete"))
-            result
+              logger.info(status_log_msg("Complete"))
+              result
+            end
           else
             logger.warn(status_log_msg("Not Implemented!"))
+            complete_task("not implemented") if params["task_id"]
+            operation_status[:not_implemented]
           end
+        rescue StandardError, NotImplementedError => e
+          complete_task(e.message) if params["task_id"]
+          raise
         end
 
         private
 
-        attr_accessor :message, :identity, :model, :method, :params, :receptor_client
+        attr_accessor :receptor_client
 
-        def status_log_msg(status = nil)
-          "Processing #{model}##{method} [#{params}]...#{status}"
+        def operation_class
+          "#{Operations}::#{model}".safe_constantize
         end
       end
     end

--- a/lib/topological_inventory/satellite/operations/source.rb
+++ b/lib/topological_inventory/satellite/operations/source.rb
@@ -18,11 +18,19 @@ module TopologicalInventory
 
         attr_accessor :source_id, :source_uid, :source_ref
 
-        def initialize(params = {}, request_context = nil, receptor_client = nil)
-          super(params, request_context)
+        def initialize(params = {}, request_context = nil, metrics = nil, receptor_client = nil)
+          super(params, request_context, metrics)
           self.connection      = TopologicalInventory::Satellite::Connection.connection(params["external_tenant"], receptor_client)
           self.source_uid      = params['source_uid']
           self.source_ref      = params['source_ref']
+        end
+
+        def availability_check
+          result = super
+          # Doesn't update metrics when waiting for async response
+          return nil if result == operation_status[:success]
+
+          result
         end
 
         # Response callback from receptor client
@@ -40,6 +48,7 @@ module TopologicalInventory
 
           logger.info("Source#availability_check for source #{source_id} completed. Status: #{status}, Result: #{response['result']}, FIFI status: #{response['fifi_status'] ? 'T' : 'F'}, Reason: #{response['message']}")
           update_source_and_subresources(status, response['message'])
+          metrics&.record_operation(operation.sub('#', '.'), :status => operation_status[:success])
         end
 
         # Timeout callback from receptor client
@@ -50,6 +59,7 @@ module TopologicalInventory
         def availability_check_timeout(msg_id)
           logger.error("Source#availability_check - Receptor doesn't respond for Source (ID #{source_id}) | (message id: #{msg_id})")
           update_source_and_subresources(STATUS_UNAVAILABLE, ERROR_MESSAGES[:receptor_not_responding])
+          metrics&.record_operation(operation.sub('#', '.'), :status => operation_status[:error])
         end
 
         private
@@ -67,9 +77,11 @@ module TopologicalInventory
             if send_availability_check(endpoint.receptor_node)
               status = STATUS_AVAILABLE
             else
+              metrics&.record_operation(operation.sub('#', '.'), :status => operation_status[:error])
               msg = ERROR_MESSAGES[:receptor_network_unreachable]
             end
           else
+            metrics&.record_operation(operation.sub('#', '.'), :status => operation_status[:error])
             msg = ERROR_MESSAGES[:receptor_node_disconnected]
           end
 

--- a/lib/topological_inventory/satellite/operations/worker.rb
+++ b/lib/topological_inventory/satellite/operations/worker.rb
@@ -3,7 +3,7 @@ require "topological_inventory/satellite/logging"
 require "topological_inventory/satellite/messaging_client"
 require "topological_inventory/satellite/receptor/client"
 require "topological_inventory/satellite/operations/processor"
-require "topological_inventory/satellite/operations/source"
+require "topological_inventory/providers/common/mixins/statuses"
 require "topological_inventory/providers/common/operations/health_check"
 
 module TopologicalInventory
@@ -11,6 +11,11 @@ module TopologicalInventory
     module Operations
       class Worker
         include Logging
+        include TopologicalInventory::Providers::Common::Mixins::Statuses
+
+        def initialize(metrics)
+          self.metrics = metrics
+        end
 
         def run
           receptor_client = TopologicalInventory::Satellite::Receptor::Client.new(:logger => logger)
@@ -28,6 +33,8 @@ module TopologicalInventory
 
         private
 
+        attr_accessor :metrics
+
         def client
           @client ||= TopologicalInventory::Satellite::MessagingClient.default.worker_listener
         end
@@ -37,10 +44,11 @@ module TopologicalInventory
         end
 
         def process_message(message, receptor_client)
-          Processor.process!(message, receptor_client)
+          result = Processor.process!(message, metrics, receptor_client)
+          metrics&.record_operation(message.message, :status => result) unless result.nil?
         rescue => e
           logger.error("#{e}\n#{e.backtrace.join("\n")}")
-          raise
+          metrics&.record_operation(message.message, :status => operation_status[:error])
         ensure
           message.ack
           TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file

--- a/spec/operations/processor_spec.rb
+++ b/spec/operations/processor_spec.rb
@@ -1,6 +1,28 @@
 require "topological_inventory/satellite/operations/processor"
 
 RSpec.describe TopologicalInventory::Satellite::Operations::Processor do
+  let(:message) { double("ManageIQ::Messaging::ReceivedMessage", :message => operation_name, :payload => payload) }
+  let(:operation_name) { 'Testing.operation' }
+  let(:params) { {'source_id' => 1, 'external_tenant' => '12345'} }
+  let(:payload) { {"params" => params, "request_context" => double('request_context')} }
+  let(:receptor_client) { double("TopologicalInventory::Satellite::Receptor::Client") }
+
+  subject { described_class.new(message, nil, receptor_client) }
+
   describe "#process" do
+    context "Source.availability_check task" do
+      let(:source_class) { TopologicalInventory::Satellite::Operations::Source }
+      let(:operation_name) { 'Source.availability_check' }
+
+      it "runs availability check" do
+        allow(TopologicalInventory::Satellite::Connection).to receive(:connection)
+        source = source_class.new(params)
+        allow(source_class).to receive(:new).and_return(source)
+
+        expect(source).to receive(:availability_check)
+
+        subject.process
+      end
+    end
   end
 end

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -4,11 +4,18 @@ RSpec.describe TopologicalInventory::Satellite::Operations::Worker do
   describe "#run" do
     let(:client) { double("ManageIQ::Messaging::Client") }
     let(:receptor_client) { double("TopologicalInventory::Satellite::Receptor::Client") }
-    let(:subject) { described_class.new }
+    let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
+    let(:metrics) { double("Metrics", :record_operation => nil) }
+    let(:operation) { 'Test.operation' }
+    let(:subject) { described_class.new(metrics) }
+
     before do
       TopologicalInventory::Satellite::MessagingClient.class_variable_set(:@@default, nil)
       allow(subject).to receive(:client).and_return(client)
       allow(client).to receive(:close)
+
+      allow(TopologicalInventory::Providers::Common::Operations::HealthCheck).to receive(:touch_file)
+      allow(message).to receive_messages(:ack => nil, :message => operation)
 
       allow(TopologicalInventory::Satellite::Receptor::Client).to receive(:new).and_return(receptor_client)
       allow(receptor_client).to receive(:start)
@@ -18,13 +25,10 @@ RSpec.describe TopologicalInventory::Satellite::Operations::Worker do
     it "calls subscribe_topic on the right queue" do
       operations_topic = "platform.topological-inventory.operations-satellite"
 
-      message = double("ManageIQ::Messaging::ReceivedMessage")
-      allow(message).to receive(:ack)
-
       expect(client).to receive(:subscribe_topic)
         .with(hash_including(:service => operations_topic)).and_yield(message)
       expect(TopologicalInventory::Satellite::Operations::Processor)
-        .to receive(:process!).with(message, receptor_client)
+        .to receive(:process!).with(message, metrics, receptor_client)
       subject.run
     end
 
@@ -36,6 +40,35 @@ RSpec.describe TopologicalInventory::Satellite::Operations::Worker do
       expect(client).to receive(:close)
 
       subject.run
+    end
+
+    context ".metrics" do
+      it "records successful operation" do
+        result = subject.operation_status[:success]
+
+        allow(TopologicalInventory::Satellite::Operations::Processor).to receive(:process!).and_return(result)
+        expect(metrics).to receive(:record_operation).with(operation, :status => result)
+
+        subject.send(:process_message, message, receptor_client)
+      end
+
+      it "records exception" do
+        result = subject.operation_status[:error]
+
+        allow(TopologicalInventory::Satellite::Operations::Processor).to receive(:process!).and_raise("Test Exception!")
+        expect(metrics).to receive(:record_operation).with(operation, :status => result)
+
+        subject.send(:process_message, message, receptor_client)
+      end
+
+      it "doesn't record metric if result is nil" do
+        result = nil
+
+        allow(TopologicalInventory::Satellite::Operations::Processor).to receive(:process!).and_return(result)
+        expect(metrics).not_to receive(:record_operation)
+
+        subject.send(:process_message, message, receptor_client)
+      end
     end
   end
 end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

Metrics for Availability_check:
* topological_inventory_satellite_operations:
  * _status_counter (args: operation name and result) [counter]
  * _duration_seconds [histogram]

**Important: Error metric replaces restart of pod in case of error**

---

* [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/57

[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)