### PR TITLE
Rubocop rules from insights-api-common

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,9 +3,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -28,5 +28,5 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-69
+    channel: rubocop-1-0
     config: ".rubocop_cc.yml"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 - .rubocop_local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,9 @@ gem "topological_inventory-ingress_api-client", "~> 1.0"
 gem "topological_inventory-providers-common", "~> 1.0.10"
 group :development, :test do
   gem "rspec"
-  gem 'rubocop',             "~>0.69.0", :require => false
-  gem 'rubocop-performance', "~>1.3",    :require => false
+  gem "rubocop",             "~> 1.0.0", :require => false
+  gem "rubocop-performance", "~> 1.8",   :require => false
+  gem "rubocop-rails",       "~> 2.8",   :require => false
   gem "simplecov",           "~>0.17.1"
   gem "webmock"
 end


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/211

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
