### PR TITLE
Add messaging client for operations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0"
-gem "topological_inventory-providers-common", "~> 1.0.10"
+gem "topological_inventory-providers-common", "~> 2.1.0"
 group :development, :test do
   gem "rspec"
   gem "rubocop",             "~> 1.0.0", :require => false

--- a/bin/satellite-operations
+++ b/bin/satellite-operations
@@ -42,5 +42,15 @@ TopologicalInventory::Satellite::Receptor::Client.configure do |config|
   config.queue_port        = args[:queue_port]
 end
 
-operations_worker = TopologicalInventory::Satellite::Operations::Worker.new(:host => args[:queue_host], :port => args[:queue_port])
-operations_worker.run
+TopologicalInventory::Satellite::MessagingClient.configure do |config|
+  config.queue_host = args[:queue_host]
+  config.queue_port = args[:queue_port]
+end
+
+begin
+  operations_worker = TopologicalInventory::Satellite::Operations::Worker.new(:metrics => metrics)
+  operations_worker.run
+rescue => err
+  puts err
+  raise
+end

--- a/lib/topological_inventory/satellite/messaging_client.rb
+++ b/lib/topological_inventory/satellite/messaging_client.rb
@@ -1,0 +1,39 @@
+require "manageiq-messaging"
+require "topological_inventory/providers/common/messaging_client"
+
+module TopologicalInventory
+  module Satellite
+    class MessagingClient < TopologicalInventory::Providers::Common::MessagingClient
+      OPERATIONS_QUEUE_NAME = "platform.topological-inventory.operations-satellite".freeze
+
+      # Instance of messaging client for Worker
+      def worker_listener
+        @worker_listener ||= ManageIQ::Messaging::Client.open(worker_listener_opts)
+      end
+
+      def worker_listener_queue_opts
+        {
+          :auto_ack    => false,
+          :max_bytes   => 50_000,
+          :service     => OPERATIONS_QUEUE_NAME,
+          :persist_ref => "topological-inventory-operations-satellite"
+        }
+      end
+
+      private
+
+      def worker_listener_opts
+        {
+          :client_ref => default_client_ref,
+          :host       => @queue_host,
+          :port       => @queue_port,
+          :protocol   => :Kafka
+        }
+      end
+
+      def default_client_ref
+        ENV['HOSTNAME'].presence || SecureRandom.hex(4)
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/satellite/operations/worker.rb
+++ b/lib/topological_inventory/satellite/operations/worker.rb
@@ -1,5 +1,6 @@
 require "manageiq-messaging"
 require "topological_inventory/satellite/logging"
+require "topological_inventory/satellite/messaging_client"
 require "topological_inventory/satellite/receptor/client"
 require "topological_inventory/satellite/operations/processor"
 require "topological_inventory/satellite/operations/source"
@@ -11,18 +12,12 @@ module TopologicalInventory
       class Worker
         include Logging
 
-        def initialize(messaging_client_opts = {})
-          self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
-        end
-
         def run
           receptor_client = TopologicalInventory::Satellite::Receptor::Client.new(:logger => logger)
           receptor_client.start
 
-          # Open a connection to the messaging service
-          client = ManageIQ::Messaging::Client.open(messaging_client_opts)
-
           logger.info("Topological Inventory Satellite Operations worker started...")
+
           client.subscribe_topic(queue_opts) do |message|
             process_message(message, receptor_client)
           end
@@ -33,7 +28,13 @@ module TopologicalInventory
 
         private
 
-        attr_accessor :messaging_client_opts
+        def client
+          @client ||= TopologicalInventory::Satellite::MessagingClient.default.worker_listener
+        end
+
+        def queue_opts
+          TopologicalInventory::Satellite::MessagingClient.default.worker_listener_queue_opts
+        end
 
         def process_message(message, receptor_client)
           Processor.process!(message, receptor_client)
@@ -43,27 +44,6 @@ module TopologicalInventory
         ensure
           message.ack
           TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file
-        end
-
-        def queue_name
-          "platform.topological-inventory.operations-satellite"
-        end
-
-        def queue_opts
-          {
-            :auto_ack    => false,
-            :max_bytes   => 50_000,
-            :service     => queue_name,
-            :persist_ref => "topological-inventory-operations-satellite"
-          }
-        end
-
-        def default_messaging_opts
-          {
-            :protocol   => :Kafka,
-            :client_ref => "topological-inventory-operations-satellite",
-            :group_ref  => "topological-inventory-operations-satellite"
-          }
         end
       end
     end

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe TopologicalInventory::Satellite::Operations::Worker do
     let(:receptor_client) { double("TopologicalInventory::Satellite::Receptor::Client") }
     let(:subject) { described_class.new }
     before do
-      require "manageiq-messaging"
-      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      TopologicalInventory::Satellite::MessagingClient.class_variable_set(:@@default, nil)
+      allow(subject).to receive(:client).and_return(client)
       allow(client).to receive(:close)
 
       allow(TopologicalInventory::Satellite::Receptor::Client).to receive(:new).and_return(receptor_client)


### PR DESCRIPTION
Adding a new messaging client similiar to the ansible-tower repo to be more consitent.

This PR is based on the https://issues.redhat.com/browse/RHCLOUD-9328