### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # topological_inventory-satellite
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-satellite.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-satellite)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-satellite.svg?branch=master)](https://travis-ci.come/RedHatInsights/topological_inventory-satellite)
 [![Maintainability](https://api.codeclimate.com/v1/badges/5c84ae84b70c4462638d/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-satellite/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/5c84ae84b70c4462638d/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-satellite/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-satellite/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-satellite/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.