### PR TITLE
Bump Providers-Common to 2.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0"
-gem "topological_inventory-providers-common", "~> 2.1.2"
+gem "topological_inventory-providers-common", "~> 2.1.3"
 group :development, :test do
   gem "rspec"
   gem "rubocop",             "~> 1.0.0", :require => false

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe TopologicalInventory::Satellite::Operations::Source do
 
     context "via kafka" do
       it "makes a patch request to update the availability_status of a source" do
-        expect(TopologicalInventory::Providers::Common::MessagingClient.default.client).to receive(:publish_message).with(
+        expect(TopologicalInventory::Providers::Common::MessagingClient.default.client).to receive(:publish_topic).with(
           {
-            :message => "availability_status",
+            :event   => "availability_status",
             :payload => "{\"resource_type\":\"Source\",\"resource_id\":\"201\",\"status\":\"available\"}",
             :service => "platform.sources.status"
           }


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/sources-api/issues/286

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/70

---

[RHCLOUD-10879](https://issues.redhat.com/browse/RHCLOUD-10879)