### PR TITLE
Fix double-updating of metrics

### DIFF
--- a/lib/topological_inventory/satellite/operations/source.rb
+++ b/lib/topological_inventory/satellite/operations/source.rb
@@ -37,11 +37,10 @@ module TopologicalInventory
           if status == STATUS_UNAVAILABLE
             update_source_and_subresources(status, error_message)
             logger.availability_check("Completed: Source #{source_id} is #{status}")
-            operation_status[:success]
-          else
-            # Doesn't update metrics when waiting for async response
-            nil
           end
+
+          # Doesn't double-update metrics
+          nil
         end
 
         # Response callback from receptor client

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe TopologicalInventory::Satellite::Operations::Source do
       expect(subject).to receive(:connection_status).and_return(described_class::STATUS_UNAVAILABLE)
       expect(subject).to receive(:update_source_and_subresources)
 
-      expect(subject.send(:availability_check)).to eq(subject.operation_status[:success])
+      expect(subject.send(:availability_check)).to be_nil
     end
 
     it "doesn't update the Source if status is available (waits for async)" do


### PR DESCRIPTION
Unavailable availability check also added :success to metrics, fixed

---

[RHCLOUD-11734](https://issues.redhat.com/browse/RHCLOUD-11734)